### PR TITLE
Modified the database migration command

### DIFF
--- a/roles/maas_region_controller/tasks/install_maas.yaml
+++ b/roles/maas_region_controller/tasks/install_maas.yaml
@@ -65,7 +65,7 @@
   when: maas_ha_postgres_enabled|bool
 
 - name: Migrate MAAS database
-  ansible.builtin.command: "{{ 'maas' if maas_installation_type | lower == 'snap' else 'maas-region' }} migrate"
+  ansible.builtin.command: "{{ 'maas' if maas_installation_type | lower == 'snap' else 'maas-region' }} dbupgrade"
   changed_when: false
   register: pg_migrate
   until: pg_migrate is not failed


### PR DESCRIPTION
from 'migrate' to 'dbupgrade' in the 'Migrate MAAS database' task in the 'maas_region_controller' role.

See more info here: https://discourse.maas.io/t/relation-maasserver-routable-pairs-does-not-exist/8682