### PR TITLE
Resolve Molecule idempotence errors in `site.yaml`

### DIFF
--- a/roles/maas_rack_controller/tasks/upgrade_maas.yaml
+++ b/roles/maas_rack_controller/tasks/upgrade_maas.yaml
@@ -1,7 +1,9 @@
 ---
 - name: Update MAAS - Snap
   ansible.builtin.command: snap refresh --channel={{ maas_version }}/{{ maas_snap_channel }} maas
+  register: maas_snap_refresh
   when: maas_installation_type | lower == 'snap'
+  changed_when: "'no updates available' not in maas_snap_refresh.stderr"
 
 - name: Add MAAS apt Repository
   ansible.builtin.apt_repository:

--- a/roles/maas_region_controller/tasks/main.yaml
+++ b/roles/maas_region_controller/tasks/main.yaml
@@ -38,12 +38,18 @@
   register: maas_admin_api_key
   changed_when: false
 
+- name: "Check MAAS login status"
+  ansible.builtin.command: maas list
+  register: maas_login_status
+  changed_when: false
+
 - name: "Login in MAAS"
   ansible.builtin.command: maas login {{ admin_username }} {{ maas_url }} {{ maas_admin_api_key.stdout }}
   environment:
     http_proxy: ""
     https_proxy: ""
     no_proxy: "localhost,hostvars[inventory_hostname]['ansible_env'].SSH_CONNECTION.split(' ')[2]"
+  when: (admin_username + " " + maas_url) not in maas_login_status.stdout
   changed_when: true
   register: login
   until: login is not failed

--- a/roles/maas_region_controller/tasks/update_maas.yaml
+++ b/roles/maas_region_controller/tasks/update_maas.yaml
@@ -1,7 +1,9 @@
 ---
 - name: Update MAAS - Snap
   ansible.builtin.command: snap refresh --channel={{ maas_version }}/{{ maas_snap_channel }} maas
+  register: maas_snap_refresh
   when: maas_installation_type | lower == 'snap'
+  changed_when: "'no updates available' not in maas_snap_refresh.stderr"
 
 - name: Add MAAS apt Repository
   ansible.builtin.apt_repository:


### PR DESCRIPTION
Several commands used in the `site.yaml` playbook fail [Molecule](https://ansible.readthedocs.io/projects/molecule/)'s idempotence tests, as they do not adequately report when a change has or has not occurred.

This patch adds appropriate `changed_when` conditions to resolve these errors.